### PR TITLE
Attach onclick handler when using pre-existing div

### DIFF
--- a/src/slippymap.crosshairs.js
+++ b/src/slippymap.crosshairs.js
@@ -41,17 +41,17 @@ slippymap.crosshairs = (function(){
 		var coords = document.createElement("div");
 		coords.setAttribute("id", "slippymap-coords");
 
-		coords.onclick = function(){
-		    latlon = (latlon) ? false : true;
-		    self.draw_coords(map);
-		    return;
-		};
-
 		var container = map.getContainer();
 		var container_el = document.getElementById(container.id);
 
 		container_el.parentNode.insertBefore(coords, container_el.nextSibling); 
 	    }
+
+	    coords.onclick = function(){
+		latlon = (latlon) ? false : true;
+		self.draw_coords(map);
+		return;
+	    };
 
 	    var pos = map.getCenter();
 	    var lat = pos['lat'];


### PR DESCRIPTION
Previously, the `onclick()` handler for the slippymap crosshairs info div was not being registered if an existing div was being used (rather than creating a new one on the fly).

I ran across this issue as part of the changes I'm preparing for whosonfirst/whosonfirst-www-spelunker#119